### PR TITLE
DEVOPS-1684: feat(aws security): allow parametrized web acl metric names

### DIFF
--- a/deployment/aws-waf-security-automations.template
+++ b/deployment/aws-waf-security-automations.template
@@ -543,7 +543,22 @@
         "DefaultAction": {
           "Type": "ALLOW"
         },
-        "MetricName": "SecurityAutomationsMaliciousRequesters",
+        "MetricName": {
+          "Fn::Join": ["",
+            [
+              {
+                "Fn::Join": ["",
+                  {
+                    "Fn::Split": ["-",
+                      {"Ref": "AWS::StackName"}
+                    ]
+                  }
+                ]
+              },
+              "WAFRequesters"
+            ]
+          ]
+        },
         "Rules": [{
           "Action": {
             "Type": "ALLOW"
@@ -728,7 +743,23 @@
             "REGION": {
               "Ref": "AWS::Region"
             },
-            "LOG_TYPE": "cloudfront"
+            "LOG_TYPE": "cloudfront",
+            "ACL_METRIC_NAME": {
+              "Fn::Join": ["",
+                [
+                  {
+                    "Fn::Join": ["",
+                      {
+                        "Fn::Split": ["-",
+                          {"Ref": "AWS::StackName"}
+                        ]
+                      }
+                    ]
+                  },
+                  "WAFRequesters"
+                ]
+              ]
+            }
           }
         },
         "Runtime": "python2.7",
@@ -895,8 +926,24 @@
             },
             "UUID": {
               "Fn::GetAtt": ["CreateUniqueID", "UUID"]
+            },
+            "ACL_METRIC_NAME": {
+              "Fn::Join": ["",
+                [
+                  {
+                    "Fn::Join": ["",
+                      {
+                        "Fn::Split": ["-",
+                          {"Ref": "AWS::StackName"}
+                        ]
+                      }
+                    ]
+                  },
+                  "WAFRequesters"
+                ]
+              ]
             }
-          }
+	  }
         }
       }
     },
@@ -1093,7 +1140,23 @@
             "REGION": {
               "Ref": "AWS::Region"
             },
-            "LOG_TYPE": "cloudfront"
+            "LOG_TYPE": "cloudfront",
+            "ACL_METRIC_NAME":{
+              "Fn::Join": ["",
+                [
+                  {
+                    "Fn::Join": ["",
+                      { 
+                        "Fn::Split": ["-",
+                          {"Ref": "AWS::StackName"}
+                        ]
+                      }
+                    ]
+                  },
+                  "WAFRequesters"
+                ]
+              ]
+            }
           }
         },
         "Runtime": "python2.7",

--- a/source/access-handler/access-handler.py
+++ b/source/access-handler/access-handler.py
@@ -105,7 +105,7 @@ def send_anonymous_usage_data():
                     },
                     {
                         "Name": "WebACL",
-                        "Value": "SecurityAutomationsMaliciousRequesters"
+                        "Value": environ['ACL_METRIC_NAME']
                     }
                 ]
             )
@@ -132,7 +132,7 @@ def send_anonymous_usage_data():
                     },
                     {
                         "Name": "WebACL",
-                        "Value": "SecurityAutomationsMaliciousRequesters"
+                        "Value": environ['ACL_METRIC_NAME']
                     }
                 ]
             )
@@ -159,7 +159,7 @@ def send_anonymous_usage_data():
                     },
                     {
                         "Name": "WebACL",
-                        "Value": "SecurityAutomationsMaliciousRequesters"
+                        "Value": environ['ACL_METRIC_NAME']
                     }
                 ]
             )

--- a/source/log-parser/log-parser.py
+++ b/source/log-parser/log-parser.py
@@ -398,7 +398,7 @@ def send_anonymous_usage_data():
                     },
                     {
                         "Name": "WebACL",
-                        "Value": "SecurityAutomationsMaliciousRequesters"
+                        "Value": environ['ACL_METRIC_NAME']
                     }
                 ]
             )
@@ -425,7 +425,7 @@ def send_anonymous_usage_data():
                     },
                     {
                         "Name": "WebACL",
-                        "Value": "SecurityAutomationsMaliciousRequesters"
+                        "Value": environ['ACL_METRIC_NAME']
                     }
                 ]
             )
@@ -452,7 +452,7 @@ def send_anonymous_usage_data():
                     },
                     {
                         "Name": "WebACL",
-                        "Value": "SecurityAutomationsMaliciousRequesters"
+                        "Value": environ['ACL_METRIC_NAME']
                     }
                 ]
             )
@@ -479,7 +479,7 @@ def send_anonymous_usage_data():
                     },
                     {
                         "Name": "WebACL",
-                        "Value": "SecurityAutomationsMaliciousRequesters"
+                        "Value": environ['ACL_METRIC_NAME']
                     }
                 ]
             )

--- a/source/reputation-lists-parser/reputation-lists-parser.js
+++ b/source/reputation-lists-parser/reputation-lists-parser.js
@@ -304,7 +304,7 @@ function send_anonymous_usage_data(event, context) {
                     Value: "ALL"
                 }, {
                     Name: "WebACL",
-                    Value: "SecurityAutomationsMaliciousRequesters"
+                    Value: process.env.ACL_METRIC_NAME
                 }]
             };
             cloudwatch.getMetricStatistics(params, function(err, data) {
@@ -338,7 +338,7 @@ function send_anonymous_usage_data(event, context) {
                     Value: "ALL"
                 }, {
                     Name: "WebACL",
-                    Value: "SecurityAutomationsMaliciousRequesters"
+                    Value: process.env.ACL_METRIC_NAME
                 }]
             };
             cloudwatch.getMetricStatistics(params, function(err, data) {
@@ -372,7 +372,7 @@ function send_anonymous_usage_data(event, context) {
                     Value: "ALL"
                 }, {
                     Name: "WebACL",
-                    Value: "SecurityAutomationsMaliciousRequesters"
+                    Value: process.env.ACL_METRIC_NAME
                 }]
             };
             cloudwatch.getMetricStatistics(params, function(err, data) {
@@ -406,7 +406,7 @@ function send_anonymous_usage_data(event, context) {
                     Value: "ALL"
                 }, {
                     Name: "WebACL",
-                    Value: "SecurityAutomationsMaliciousRequesters"
+                    Value: process.env.ACL_METRIC_NAME
                 }]
             };
             cloudwatch.getMetricStatistics(params, function(err, data) {


### PR DESCRIPTION
This PR falls into two sections:
1 Changes to the aws template and lambdas to replace the previously hard-coded web acl metric name SecurityAutomationsMaliciousRequesters with a parametrized one using the stack-name (alpha-numerised), e.g. stagingdmswafWafRequesters.
2 The addition of a bucket to store the changed lambdas (until/if/when the changes might be incorporated into the AWS lambdas in the AWS solutions bucket).