### PR TITLE
DEVOPS- 1684:custom lambda bucket

### DIFF
--- a/deployment/aws-waf-security-automations.template
+++ b/deployment/aws-waf-security-automations.template
@@ -129,6 +129,12 @@
       "Default": "240",
       "MinValue": "0",
       "Description": "If you chose yes for the Activate Scanners & Probes Protection parameters, enter the period (in minutes) to block applicable IP addresses. If you chose to deactivate this protection, ignore this parameter."
+    },
+    "LambdaBucket": {
+      "Type": "String",
+      "Default": "",
+      "AllowedPattern": "(^$|^([a-z]|(\\d(?!\\d{0,2}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})))([a-z\\d]|(\\.(?!(\\.|-)))|(-(?!\\.))){1,61}[a-z\\d]$)",
+      "Description": "Enter a name for the Amazon S3 bucket where the AWS Security Solutions WAF Lambdas are stored. More about bucket name restriction here: http://amzn.to/1p1YlU5"
     }
   },
 
@@ -706,12 +712,7 @@
           "Fn::GetAtt": ["LambdaRoleLogParser", "Arn"]
         },
         "Code": {
-          "S3Bucket": {
-            "Fn::Join": ["-", [
-              "%%BUCKET_NAME%%", {
-                "Ref": "AWS::Region"
-              }
-            ]]
+          "S3Bucket": { "Ref": "LambdaBucket"
           },
           "S3Key": "aws-waf-security-automations/v2/log-parser.zip"
         },
@@ -907,12 +908,7 @@
           ]
         },
         "Code": {
-          "S3Bucket": {
-            "Fn::Join": ["-", [
-              "%%BUCKET_NAME%%", {
-                "Ref": "AWS::Region"
-              }
-            ]]
+          "S3Bucket": { "Ref": "LambdaBucket"
           },
           "S3Key": "aws-waf-security-automations/v3/reputation-lists-parser.zip"
         },
@@ -1117,13 +1113,8 @@
           "Fn::GetAtt": ["LambdaRoleBadBot", "Arn"]
         },
         "Code": {
-          "S3Bucket": {
-            "Fn::Join": ["-", [
-              "%%BUCKET_NAME%%", {
-                "Ref": "AWS::Region"
-              }
-            ]]
-          },
+          "S3Bucket": { "Ref": "LambdaBucket"
+          } ,
           "S3Key": "aws-waf-security-automations/v2/access-handler.zip"
         },
         "Environment": {

--- a/deployment/aws-waf-security-automations.template
+++ b/deployment/aws-waf-security-automations.template
@@ -543,7 +543,22 @@
         "DefaultAction": {
           "Type": "ALLOW"
         },
-        "MetricName": "SecurityAutomationsMaliciousRequesters",
+        "MetricName": {
+          "Fn::Join": ["",
+            [
+              {
+                "Fn::Join": ["",
+                  {
+                    "Fn::Split": ["-",
+                      {"Ref": "AWS::StackName"}
+                    ]
+                  }
+                ]
+              },
+              "WAFRequesters"
+            ]
+          ]
+        },
         "Rules": [{
           "Action": {
             "Type": "ALLOW"
@@ -728,7 +743,23 @@
             "REGION": {
               "Ref": "AWS::Region"
             },
-            "LOG_TYPE": "cloudfront"
+            "LOG_TYPE": "cloudfront",
+            "ACL_METRIC_NAME": {
+              "Fn::Join": ["",
+                [
+                  {
+                    "Fn::Join": ["",
+                      {
+                        "Fn::Split": ["-",
+                          {"Ref": "AWS::StackName"}
+                        ]
+                      }
+                    ]
+                  },
+                  "WAFRequesters"
+                ]
+              ]
+            }
           }
         },
         "Runtime": "python2.7",
@@ -895,8 +926,24 @@
             },
             "UUID": {
               "Fn::GetAtt": ["CreateUniqueID", "UUID"]
+            },
+            "ACL_METRIC_NAME": {
+              "Fn::Join": ["",
+                [
+                  {
+                    "Fn::Join": ["",
+                      {
+                        "Fn::Split": ["-",
+                          {"Ref": "AWS::StackName"}
+                        ]
+                      }
+                    ]
+                  },
+                  "WAFRequesters"
+                ]
+              ]
             }
-          }
+	  }
         }
       }
     },
@@ -1093,7 +1140,23 @@
             "REGION": {
               "Ref": "AWS::Region"
             },
-            "LOG_TYPE": "cloudfront"
+            "LOG_TYPE": "cloudfront",
+            "ACL_METRIC_NAME":{
+              "Fn::Join": ["",
+                [
+                  {
+                    "Fn::Join": ["",
+                      { 
+                        "Fn::Split": ["-",
+                          {"Ref": "AWS::StackName"}
+                        ]
+                      }
+                    ]
+                  },
+                  "WAFRequesters"
+                ]
+              ]
+            }
           }
         },
         "Runtime": "python2.7",

--- a/source/access-handler/access-handler.py
+++ b/source/access-handler/access-handler.py
@@ -105,7 +105,7 @@ def send_anonymous_usage_data():
                     },
                     {
                         "Name": "WebACL",
-                        "Value": "SecurityAutomationsMaliciousRequesters"
+                        "Value": environ['ACL_METRIC_NAME']
                     }
                 ]
             )
@@ -132,7 +132,7 @@ def send_anonymous_usage_data():
                     },
                     {
                         "Name": "WebACL",
-                        "Value": "SecurityAutomationsMaliciousRequesters"
+                        "Value": environ['ACL_METRIC_NAME']
                     }
                 ]
             )
@@ -159,7 +159,7 @@ def send_anonymous_usage_data():
                     },
                     {
                         "Name": "WebACL",
-                        "Value": "SecurityAutomationsMaliciousRequesters"
+                        "Value": environ['ACL_METRIC_NAME']
                     }
                 ]
             )

--- a/source/log-parser/log-parser.py
+++ b/source/log-parser/log-parser.py
@@ -398,7 +398,7 @@ def send_anonymous_usage_data():
                     },
                     {
                         "Name": "WebACL",
-                        "Value": "SecurityAutomationsMaliciousRequesters"
+                        "Value": environ['ACL_METRIC_NAME']
                     }
                 ]
             )
@@ -425,7 +425,7 @@ def send_anonymous_usage_data():
                     },
                     {
                         "Name": "WebACL",
-                        "Value": "SecurityAutomationsMaliciousRequesters"
+                        "Value": environ['ACL_METRIC_NAME']
                     }
                 ]
             )
@@ -452,7 +452,7 @@ def send_anonymous_usage_data():
                     },
                     {
                         "Name": "WebACL",
-                        "Value": "SecurityAutomationsMaliciousRequesters"
+                        "Value": environ['ACL_METRIC_NAME']
                     }
                 ]
             )
@@ -479,7 +479,7 @@ def send_anonymous_usage_data():
                     },
                     {
                         "Name": "WebACL",
-                        "Value": "SecurityAutomationsMaliciousRequesters"
+                        "Value": environ['ACL_METRIC_NAME']
                     }
                 ]
             )

--- a/source/reputation-lists-parser/reputation-lists-parser.js
+++ b/source/reputation-lists-parser/reputation-lists-parser.js
@@ -304,7 +304,7 @@ function send_anonymous_usage_data(event, context) {
                     Value: "ALL"
                 }, {
                     Name: "WebACL",
-                    Value: "SecurityAutomationsMaliciousRequesters"
+                    Value: process.env.ACL_METRIC_NAME
                 }]
             };
             cloudwatch.getMetricStatistics(params, function(err, data) {
@@ -338,7 +338,7 @@ function send_anonymous_usage_data(event, context) {
                     Value: "ALL"
                 }, {
                     Name: "WebACL",
-                    Value: "SecurityAutomationsMaliciousRequesters"
+                    Value: process.env.ACL_METRIC_NAME
                 }]
             };
             cloudwatch.getMetricStatistics(params, function(err, data) {
@@ -372,7 +372,7 @@ function send_anonymous_usage_data(event, context) {
                     Value: "ALL"
                 }, {
                     Name: "WebACL",
-                    Value: "SecurityAutomationsMaliciousRequesters"
+                    Value: process.env.ACL_METRIC_NAME
                 }]
             };
             cloudwatch.getMetricStatistics(params, function(err, data) {
@@ -406,7 +406,7 @@ function send_anonymous_usage_data(event, context) {
                     Value: "ALL"
                 }, {
                     Name: "WebACL",
-                    Value: "SecurityAutomationsMaliciousRequesters"
+                    Value: process.env.ACL_METRIC_NAME
                 }]
             };
             cloudwatch.getMetricStatistics(params, function(err, data) {


### PR DESCRIPTION
This PR adds a custom s3 bucket to the basic aws waf template, so that cab-specific versions of the aws waf lambdas can be stored and used by waf instances created using the template (required for waf logging/notifications).